### PR TITLE
Closes #100 Hotfix: Resolve memory leak during recursive graph genome indexing

### DIFF
--- a/__tmp6/BellmanFordTest.java
+++ b/__tmp6/BellmanFordTest.java
@@ -1,0 +1,158 @@
+package com.thealgorithms.datastructures.graphs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the BellmanFord algorithm implementation.
+ * Tests cover various graph scenarios including:
+ * - Simple weighted graphs
+ * - Graphs with negative weights
+ * - Single vertex graphs
+ * - Disconnected graphs
+ * - Linear path graphs
+ */
+class BellmanFordTest {
+
+    @Test
+    void testSimpleGraph() {
+        // Create a simple graph with 5 vertices and 8 edges
+        // Graph visualization:
+        // 1
+        // /|\
+        // 6 | 7
+        // / | \
+        // 0 5 2
+        // \ | /
+        // 8 | -2
+        // \|/
+        // 4---3
+        // 9
+        BellmanFord bellmanFord = new BellmanFord(5, 8);
+        bellmanFord.addEdge(0, 1, 6);
+        bellmanFord.addEdge(0, 4, 8);
+        bellmanFord.addEdge(1, 2, 7);
+        bellmanFord.addEdge(1, 4, 5);
+        bellmanFord.addEdge(2, 3, -2);
+        bellmanFord.addEdge(2, 4, -3);
+        bellmanFord.addEdge(3, 4, 9);
+        bellmanFord.addEdge(4, 3, 7);
+
+        // Verify edge array creation
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(8, bellmanFord.getEdgeArray().length);
+    }
+
+    @Test
+    void testGraphWithNegativeWeights() {
+        // Graph with negative edge weights (but no negative cycle)
+        BellmanFord bellmanFord = new BellmanFord(4, 5);
+        bellmanFord.addEdge(0, 1, 4);
+        bellmanFord.addEdge(0, 2, 5);
+        bellmanFord.addEdge(1, 2, -3);
+        bellmanFord.addEdge(2, 3, 4);
+        bellmanFord.addEdge(1, 3, 6);
+
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(5, bellmanFord.getEdgeArray().length);
+    }
+
+    @Test
+    void testSingleVertexGraph() {
+        // Graph with single vertex and no edges
+        BellmanFord bellmanFord = new BellmanFord(1, 0);
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(0, bellmanFord.getEdgeArray().length);
+    }
+
+    @Test
+    void testLinearGraph() {
+        // Linear graph: 0 -> 1 -> 2 -> 3
+        BellmanFord bellmanFord = new BellmanFord(4, 3);
+        bellmanFord.addEdge(0, 1, 2);
+        bellmanFord.addEdge(1, 2, 3);
+        bellmanFord.addEdge(2, 3, 4);
+
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(3, bellmanFord.getEdgeArray().length);
+    }
+
+    @Test
+    void testEdgeAddition() {
+        BellmanFord bellmanFord = new BellmanFord(3, 3);
+
+        bellmanFord.addEdge(0, 1, 5);
+        bellmanFord.addEdge(1, 2, 3);
+        bellmanFord.addEdge(0, 2, 10);
+
+        // Verify all edges were added
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(3, bellmanFord.getEdgeArray().length);
+    }
+
+    @Test
+    void testGraphWithZeroWeightEdges() {
+        // Graph with zero weight edges
+        BellmanFord bellmanFord = new BellmanFord(3, 3);
+        bellmanFord.addEdge(0, 1, 0);
+        bellmanFord.addEdge(1, 2, 0);
+        bellmanFord.addEdge(0, 2, 1);
+
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(3, bellmanFord.getEdgeArray().length);
+    }
+
+    @Test
+    void testLargerGraph() {
+        // Larger graph with 6 vertices
+        BellmanFord bellmanFord = new BellmanFord(6, 9);
+        bellmanFord.addEdge(0, 1, 5);
+        bellmanFord.addEdge(0, 2, 3);
+        bellmanFord.addEdge(1, 3, 6);
+        bellmanFord.addEdge(1, 2, 2);
+        bellmanFord.addEdge(2, 4, 4);
+        bellmanFord.addEdge(2, 5, 2);
+        bellmanFord.addEdge(2, 3, 7);
+        bellmanFord.addEdge(3, 4, -1);
+        bellmanFord.addEdge(4, 5, -2);
+
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(9, bellmanFord.getEdgeArray().length);
+    }
+
+    @Test
+    void testVertexAndEdgeCount() {
+        BellmanFord bellmanFord = new BellmanFord(10, 15);
+        assertEquals(10, bellmanFord.vertex);
+        assertEquals(15, bellmanFord.edge);
+    }
+
+    @Test
+    void testMultipleEdgesBetweenSameVertices() {
+        // Graph allowing multiple edges between same vertices
+        BellmanFord bellmanFord = new BellmanFord(2, 3);
+        bellmanFord.addEdge(0, 1, 5);
+        bellmanFord.addEdge(0, 1, 3);
+        bellmanFord.addEdge(1, 0, 2);
+
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(3, bellmanFord.getEdgeArray().length);
+    }
+
+    @Test
+    void testCompleteGraph() {
+        // Complete graph with 4 vertices (6 edges for undirected equivalent)
+        BellmanFord bellmanFord = new BellmanFord(4, 6);
+        bellmanFord.addEdge(0, 1, 1);
+        bellmanFord.addEdge(0, 2, 2);
+        bellmanFord.addEdge(0, 3, 3);
+        bellmanFord.addEdge(1, 2, 4);
+        bellmanFord.addEdge(1, 3, 5);
+        bellmanFord.addEdge(2, 3, 6);
+
+        assertNotNull(bellmanFord.getEdgeArray());
+        assertEquals(6, bellmanFord.getEdgeArray().length);
+    }
+}

--- a/__tmp6/DijkstraAlgorithm.java
+++ b/__tmp6/DijkstraAlgorithm.java
@@ -1,0 +1,91 @@
+package com.thealgorithms.datastructures.graphs;
+
+import java.util.Arrays;
+
+/**
+ * Dijkstra's algorithm for finding the shortest path from a single source vertex to all other vertices in a graph.
+ */
+public class DijkstraAlgorithm {
+
+    private final int vertexCount;
+
+    /**
+     * Constructs a Dijkstra object with the given number of vertices.
+     *
+     * @param vertexCount The number of vertices in the graph.
+     */
+    public DijkstraAlgorithm(int vertexCount) {
+        this.vertexCount = vertexCount;
+    }
+
+    /**
+     * Executes Dijkstra's algorithm on the provided graph to find the shortest paths from the source vertex to all other vertices.
+     *
+     * The graph is represented as an adjacency matrix where {@code graph[i][j]} represents the weight of the edge from vertex {@code i}
+     * to vertex {@code j}. A value of 0 indicates no edge exists between the vertices.
+     *
+     * @param graph The graph represented as an adjacency matrix.
+     * @param source The source vertex.
+     * @return An array where the value at each index {@code i} represents the shortest distance from the source vertex to vertex {@code i}.
+     * @throws IllegalArgumentException if the source vertex is out of range.
+     */
+    public int[] run(int[][] graph, int source) {
+        if (source < 0 || source >= vertexCount) {
+            throw new IllegalArgumentException("Incorrect source");
+        }
+
+        int[] distances = new int[vertexCount];
+        boolean[] processed = new boolean[vertexCount];
+
+        Arrays.fill(distances, Integer.MAX_VALUE);
+        Arrays.fill(processed, false);
+        distances[source] = 0;
+
+        for (int count = 0; count < vertexCount - 1; count++) {
+            int u = getMinDistanceVertex(distances, processed);
+            processed[u] = true;
+
+            for (int v = 0; v < vertexCount; v++) {
+                if (!processed[v] && graph[u][v] != 0 && distances[u] != Integer.MAX_VALUE && distances[u] + graph[u][v] < distances[v]) {
+                    distances[v] = distances[u] + graph[u][v];
+                }
+            }
+        }
+
+        printDistances(distances);
+        return distances;
+    }
+
+    /**
+     * Finds the vertex with the minimum distance value from the set of vertices that have not yet been processed.
+     *
+     * @param distances The array of current shortest distances from the source vertex.
+     * @param processed The array indicating whether each vertex has been processed.
+     * @return The index of the vertex with the minimum distance value.
+     */
+    private int getMinDistanceVertex(int[] distances, boolean[] processed) {
+        int min = Integer.MAX_VALUE;
+        int minIndex = -1;
+
+        for (int v = 0; v < vertexCount; v++) {
+            if (!processed[v] && distances[v] <= min) {
+                min = distances[v];
+                minIndex = v;
+            }
+        }
+
+        return minIndex;
+    }
+
+    /**
+     * Prints the shortest distances from the source vertex to all other vertices.
+     *
+     * @param distances The array of shortest distances.
+     */
+    private void printDistances(int[] distances) {
+        System.out.println("Vertex \t Distance");
+        for (int i = 0; i < vertexCount; i++) {
+            System.out.println(i + " \t " + distances[i]);
+        }
+    }
+}

--- a/__tmp6/README.md
+++ b/__tmp6/README.md
@@ -1,0 +1,72 @@
+# Minimax algorithm
+
+<p align="center"> <img src="Resources/image1.jpg" {:height="50%" width="50%"} /> </p>
+
+## Runtime environment
+<img src="https://img.shields.io/badge/Swift-5.3-orange.svg?style=flat" />
+<img src="https://img.shields.io/badge/Xcode-12.4-blue.svg?style=flat" />
+<img src="https://img.shields.io/badge/MacOS-11.2.3-blue.svg?style=flat" />
+
+## Table of contents
+* [General info](#general-info)
+* [Functionality](#functionality)
+* [Pseudocode](#pseudocode)
+* [Demo](#demo)
+* [Sources](#sources)
+
+## General info
+It is an example of implementation and use ``minimax algorithm`` in ``Tic Tac Toe`` game. Minimax is an algorithm that searches deeply into all possible states in the game. There are two types of players in the algorithm. One that wants to maximize the state of the game and one that wants to minimaze the state of the game. There are three states in the tic-tac-toe game:
+- `` -1 `` - if the minimizing player wins
+- `` 0 `` - in case of a tie
+- `` 1 `` - if the maximizing player wins
+
+``Alpha-beta prunning`` this is a method that interrupts the search of those branches that do not lead to win. Alpha for maximizing player and beta for minimizing player. Alpha-beta prunnings reduce the time complexity of the algorithm.
+
+Parameters:
+- ``searching depth`` - how many moves in depth is to be calculated by the algorithm
+
+Input:
+- ``actual board state`` - in the form of an array for players symbols (cross/circle)
+- ``two player symbols`` - cross / circle
+
+Output:
+- ``the best move for autonomus(AI) player`` - Position(row: Int, column: Int)
+
+## Functionality
+- example of use in Swift Playground with interactive UIView
+- unit tests in XCode
+
+## Pseudocode
+
+```
+function alphabeta(node, depth, α, β, maximizingPlayer) is
+    if depth = 0 or node is a terminal node then
+        return the heuristic value of node
+    if maximizingPlayer then
+        value := −∞
+        for each child of node do
+            value := max(value, alphabeta(child, depth − 1, α, β, FALSE))
+            if value ≥ β then
+                break (* β cutoff *)
+            α := max(α, value)
+        return value
+    else
+        value := +∞
+        for each child of node do
+            value := min(value, alphabeta(child, depth − 1, α, β, TRUE))
+            if value ≤ α then
+                break (* α cutoff *)
+            β := min(β, value)
+        return value
+```
+
+## Demo
+
+<p align="center"> <img src="Resources/demo.gif" {:height="100%" width="100%"} /> </p>
+
+## Sources
+* Minimax algorithm: https://en.wikipedia.org/wiki/Minimax
+* Alpha-beta prunning: https://en.wikipedia.org/wiki/Alpha–beta_pruning
+
+## Author
+Written by Michał Nowak(mnowak061)

--- a/__tmp6/RailwayTimeConversion.js
+++ b/__tmp6/RailwayTimeConversion.js
@@ -1,0 +1,46 @@
+/*
+    The time conversion of normalized time to the railway is a simple algorithm
+    because we know that if the time is in 'AM' value it means they only want
+    some changes on hours and minutes and if the time in 'PM' it means the only
+    want some changes in hour value.
+
+    Input Format -> 07:05:45PM
+    Output Format -> 19:05:45
+
+    Problem & Explanation Source : https://www.mathsisfun.com/time.html
+*/
+
+/**
+ * RailwayTimeConversion method converts normalized time string to Railway time string.
+ * @param {String} timeString Normalized time string.
+ * @returns {String} Railway time string.
+ */
+const RailwayTimeConversion = (timeString) => {
+  // firstly, check that input is a string or not.
+  if (typeof timeString !== 'string') {
+    throw new TypeError('Argument is not a string.')
+  }
+  // split the string by ':' character.
+  const [hour, minute, secondWithShift] = timeString.split(':')
+  // split second and shift value.
+  const [second, shift] = [
+    secondWithShift.substring(0, 2),
+    secondWithShift.substring(2)
+  ]
+  // convert shifted time to not-shift time(Railway time) by using the above explanation.
+  if (shift === 'PM') {
+    if (parseInt(hour) === 12) {
+      return `${hour}:${minute}:${second}`
+    } else {
+      return `${parseInt(hour) + 12}:${minute}:${second}`
+    }
+  } else {
+    if (parseInt(hour) === 12) {
+      return `00:${minute}:${second}`
+    } else {
+      return `${hour}:${minute}:${second}`
+    }
+  }
+}
+
+export { RailwayTimeConversion }

--- a/__tmp6/brent_method_extrema.cpp
+++ b/__tmp6/brent_method_extrema.cpp
@@ -1,0 +1,216 @@
+/**
+ * \file
+ * \brief Find real extrema of a univariate real function in a given interval
+ * using [Brent's method](https://en.wikipedia.org/wiki/Brent%27s_method).
+ *
+ * Refer the algorithm discoverer's publication
+ * [online](https://maths-people.anu.edu.au/~brent/pd/rpb011i.pdf) and also
+ * associated book:
+ * > R. P. Brent, Algorithms for Minimization without
+ * > Derivatives, Prentice-Hall, Englewood Cliffs, New Jersey, 1973
+ *
+ * \see golden_search_extrema.cpp
+ *
+ * \author [Krishna Vedala](https://github.com/kvedala)
+ */
+#define _USE_MATH_DEFINES  ///< required for MS Visual C++
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <limits>
+
+#define EPSILON \
+    std::sqrt(  \
+        std::numeric_limits<double>::epsilon())  ///< system accuracy limit
+
+/**
+ * @brief Get the real root of a function in the given interval.
+ *
+ * @param f function to get root for
+ * @param lim_a lower limit of search window
+ * @param lim_b upper limit of search window
+ * @return root found in the interval
+ */
+double get_minima(const std::function<double(double)> &f, double lim_a,
+                  double lim_b) {
+    uint32_t iters = 0;
+
+    if (lim_a > lim_b) {
+        std::swap(lim_a, lim_b);
+    } else if (std::abs(lim_a - lim_b) <= EPSILON) {
+        std::cerr << "Search range must be greater than " << EPSILON << "\n";
+        return lim_a;
+    }
+
+    // golden ratio value
+    const double M_GOLDEN_RATIO = (3.f - std::sqrt(5.f)) / 2.f;
+
+    double v = lim_a + M_GOLDEN_RATIO * (lim_b - lim_a);
+    double u, w = v, x = v;
+    double fu, fv = f(v);
+    double fw = fv, fx = fv;
+
+    double mid_point = (lim_a + lim_b) / 2.f;
+    double p = 0, q = 0, r = 0;
+
+    double d, e = 0;
+    double tolerance, tolerance2;
+
+    do {
+        mid_point = (lim_a + lim_b) / 2.f;
+        tolerance = EPSILON * std::abs(x);
+        tolerance2 = 2 * tolerance;
+
+        if (std::abs(e) > tolerance2) {
+            // fit parabola
+            r = (x - w) * (fx - fv);
+            q = (x - v) * (fx - fw);
+            p = (x - v) * q - (x - w) * r;
+            q = 2.f * (q - r);
+            if (q > 0)
+                p = -p;
+            else
+                q = -q;
+            r = e;
+            e = d;
+        }
+
+        if (std::abs(p) < std::abs(0.5 * q * r) && p < q * (lim_b - x)) {
+            // parabolic interpolation step
+            d = p / q;
+            u = x + d;
+            if (u - lim_a < tolerance2 || lim_b - u < tolerance2)
+                d = x < mid_point ? tolerance : -tolerance;
+        } else {
+            // golden section interpolation step
+            e = (x < mid_point ? lim_b : lim_a) - x;
+            d = M_GOLDEN_RATIO * e;
+        }
+
+        // evaluate not too close to x
+        if (std::abs(d) >= tolerance)
+            u = d;
+        else if (d > 0)
+            u = tolerance;
+        else
+            u = -tolerance;
+        u += x;
+        fu = f(u);
+
+        // update variables
+        if (fu <= fx) {
+            if (u < x)
+                lim_b = x;
+            else
+                lim_a = x;
+            v = w;
+            fv = fw;
+            w = x;
+            fw = fx;
+            x = u;
+            fx = fu;
+        } else {
+            if (u < x)
+                lim_a = u;
+            else
+                lim_b = u;
+            if (fu <= fw || x == w) {
+                v = w;
+                fv = fw;
+                w = u;
+                fw = fu;
+            } else if (fu <= fv || v == x || v == w) {
+                v = u;
+                fv = fu;
+            }
+        }
+
+        iters++;
+    } while (std::abs(x - mid_point) > (tolerance - (lim_b - lim_a) / 2.f));
+
+    std::cout << " (iters: " << iters << ") ";
+
+    return x;
+}
+
+/**
+ * @brief Test function to find root for the function
+ * \f$f(x)= (x-2)^2\f$
+ * in the interval \f$[1,5]\f$
+ * \n Expected result = 2
+ */
+void test1() {
+    // define the function to minimize as a lambda function
+    std::function<double(double)> f1 = [](double x) {
+        return (x - 2) * (x - 2);
+    };
+
+    std::cout << "Test 1.... ";
+
+    double minima = get_minima(f1, -1, 5);
+
+    std::cout << minima << "...";
+
+    assert(std::abs(minima - 2) < EPSILON);
+    std::cout << "passed\n";
+}
+
+/**
+ * @brief Test function to find root for the function
+ * \f$f(x)= x^{\frac{1}{x}}\f$
+ * in the interval \f$[-2,10]\f$
+ * \n Expected result: \f$e\approx 2.71828182845904509\f$
+ */
+void test2() {
+    // define the function to maximize as a lambda function
+    // since we are maximixing, we negated the function return value
+    std::function<double(double)> func = [](double x) {
+        return -std::pow(x, 1.f / x);
+    };
+
+    std::cout << "Test 2.... ";
+
+    double minima = get_minima(func, -2, 5);
+
+    std::cout << minima << " (" << M_E << ")...";
+
+    assert(std::abs(minima - M_E) < EPSILON);
+    std::cout << "passed\n";
+}
+
+/**
+ * @brief Test function to find *maxima* for the function
+ * \f$f(x)= \cos x\f$
+ * in the interval \f$[0,12]\f$
+ * \n Expected result: \f$\pi\approx 3.14159265358979312\f$
+ */
+void test3() {
+    // define the function to maximize as a lambda function
+    // since we are maximixing, we negated the function return value
+    std::function<double(double)> func = [](double x) { return std::cos(x); };
+
+    std::cout << "Test 3.... ";
+
+    double minima = get_minima(func, -4, 12);
+
+    std::cout << minima << " (" << M_PI << ")...";
+
+    assert(std::abs(minima - M_PI) < EPSILON);
+    std::cout << "passed\n";
+}
+
+/** Main function */
+int main() {
+    std::cout.precision(18);
+
+    std::cout << "Computations performed with machine epsilon: " << EPSILON
+              << "\n";
+
+    test1();
+    test2();
+    test3();
+
+    return 0;
+}

--- a/__tmp6/monte_carlo.f90
+++ b/__tmp6/monte_carlo.f90
@@ -1,0 +1,45 @@
+!> Example Program for Monte Carlo Integration
+!!
+!!  Created by: Ramy-Badr-Ahmed (https://github.com/Ramy-Badr-Ahmed)
+!!  in Pull Request: #25
+!!  https://github.com/TheAlgorithms/Fortran/pull/25
+!!
+!!  Please mention me (@Ramy-Badr-Ahmed) in any issue or pull request
+!!  addressing bugs/corrections to this file. Thank you!
+!!
+!! This program demonstrates the use of Monte Carlo module for numerical integration.
+!!
+!! It sets the integration limits and number of random samples, and calls the
+!! monte_carlo subroutine to compute the approximate value of the definite integral
+!! of the specified function.
+!!
+!! Example function: f(x) = exp(-x^2) * cos(2.0_dp * x)
+
+program example_monte_carlo
+    use monte_carlo_integration
+    implicit none
+
+    real(dp) :: lower_bound, upper_bound, integral_result, error_estimate
+    integer :: random_samples_number
+
+    ! Set the integration limits and number of random samples
+    lower_bound = -1.0_dp
+    upper_bound = 1.0_dp
+    random_samples_number = 1000000     !! 1E6 Number of random samples
+
+    ! Call Monte Carlo integration with the function passed as an argument
+    call monte_carlo(integral_result, error_estimate, lower_bound, upper_bound, random_samples_number, function)
+
+    write (*, '(A, F12.6, A, F12.6)') "Monte Carlo result: ", integral_result, " +- ", error_estimate     !! ≈ 0.858421
+
+contains
+
+    function function(x) result(fx)
+        implicit none
+        real(dp), intent(in) :: x
+        real(dp) :: fx
+
+        fx = exp(-x**2)*cos(2.0_dp*x)       !! Example function to integrate
+    end function function
+
+end program example_monte_carlo


### PR DESCRIPTION
100 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.